### PR TITLE
解决抗锯齿不生效问题

### DIFF
--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -101,7 +101,14 @@ Page({
     this.platform = platform;
     // platform.enableDeviceOrientation('game');
     threePlatformize.PLATFORM.set(platform);
+    let {width,height} = canvas;
+    console.log(canvas.width,canvas.height)
+    let gl = canvas.getContext('webgl');
+    let {pixelRatio}  = tt.getSystemInfoSync();
 
+    gl.canvas.width = width * pixelRatio
+    gl.canvas.height = height * pixelRatio
+    gl.viewport(0, 0, width * pixelRatio, height * pixelRatio);
     console.log(threePlatformize.$window.innerWidth, threePlatformize.$window.innerHeight);
     console.log(canvas.width, canvas.height);
 


### PR DESCRIPTION
依据微信开发者社区提供的修复意见 将gl的逻辑像素高度与宽度 设置为 DRP*width|height
[详情](https://developers.weixin.qq.com/community/develop/doc/000206063d0708398a981410456400)